### PR TITLE
Changes in DSL after feedback in docs

### DIFF
--- a/src/main/kotlin/pl/allegro/logic/operators/logic/AndOperation.kt
+++ b/src/main/kotlin/pl/allegro/logic/operators/logic/AndOperation.kt
@@ -3,6 +3,7 @@ package pl.allegro.logic.operators.logic
 import pl.allegro.logic.ClientLogicElement
 import pl.allegro.logic.ListOfClientElements
 import pl.allegro.logic.ClientLogicMarker
+import pl.allegro.logic.operators.FlattenableOperatorFactory
 import pl.allegro.logic.operators.OperatorFactory
 
 internal interface AndOperation {
@@ -10,14 +11,8 @@ internal interface AndOperation {
     fun ClientLogicElement.and(other: ClientLogicElement) = AndOperatorFactory().create(this, other)
 
     @ClientLogicMarker
-    fun firstFalsyElementOrLastElement(
-        element: ClientLogicElement,
-        vararg elements: ClientLogicElement
-    ) = AndOperatorFactory().create(element, *elements)
-
-    @ClientLogicMarker
-    fun firstFalsyElementOrLastElement(listOfElements: ListOfClientElements<in ClientLogicElement>) =
+    fun and(listOfElements: ListOfClientElements<in ClientLogicElement>) =
         AndOperatorFactory().create(listOfElements)
 }
 
-private class AndOperatorFactory : OperatorFactory("and")
+private class AndOperatorFactory : FlattenableOperatorFactory("and")

--- a/src/main/kotlin/pl/allegro/logic/operators/logic/OrOperation.kt
+++ b/src/main/kotlin/pl/allegro/logic/operators/logic/OrOperation.kt
@@ -3,6 +3,7 @@ package pl.allegro.logic.operators.logic
 import pl.allegro.logic.ClientLogicElement
 import pl.allegro.logic.ListOfClientElements
 import pl.allegro.logic.ClientLogicMarker
+import pl.allegro.logic.operators.FlattenableOperatorFactory
 import pl.allegro.logic.operators.OperatorFactory
 
 internal interface OrOperation {
@@ -12,14 +13,8 @@ internal interface OrOperation {
         OrOperatorFactory().create(this, other)
 
     @ClientLogicMarker
-    fun firstTruthyElementOrLastElement(
-        element: ClientLogicElement,
-        vararg elements: ClientLogicElement
-    ) = OrOperatorFactory().create(element, *elements)
-
-    @ClientLogicMarker
-    fun firstTruthyElementOrLastElement(elements: ListOfClientElements<in ClientLogicElement>) =
+    fun or(elements: ListOfClientElements<in ClientLogicElement>) =
         OrOperatorFactory().create(elements)
 }
 
-private class OrOperatorFactory : OperatorFactory("or")
+private class OrOperatorFactory : FlattenableOperatorFactory("or")

--- a/src/main/kotlin/pl/allegro/logic/operators/logic/StrictEqualOperation.kt
+++ b/src/main/kotlin/pl/allegro/logic/operators/logic/StrictEqualOperation.kt
@@ -9,16 +9,16 @@ import pl.allegro.logic.StringElement
 
 internal interface StrictEqualOperation {
     @ClientLogicMarker
-    fun ClientLogicElement.strictEqual(other: ClientLogicElement) = StrictEqualOperatorFactory().create(this, other)
+    fun ClientLogicElement.isStrictEqual(other: ClientLogicElement) = StrictEqualOperatorFactory().create(this, other)
 
     @ClientLogicMarker
-    fun ClientLogicElement.strictEqual(other: String) = strictEqual(StringElement(other))
+    fun ClientLogicElement.isStrictEqual(other: String) = isStrictEqual(StringElement(other))
 
     @ClientLogicMarker
-    fun ClientLogicElement.strictEqual(other: Number) = strictEqual(NumberElement(other))
+    fun ClientLogicElement.isStrictEqual(other: Number) = isStrictEqual(NumberElement(other))
 
     @ClientLogicMarker
-    fun ClientLogicElement.strictEqual(other: Boolean) = strictEqual(BooleanElement(other))
+    fun ClientLogicElement.isStrictEqual(other: Boolean) = isStrictEqual(BooleanElement(other))
 }
 
 private class StrictEqualOperatorFactory : OperatorFactory("===")

--- a/src/main/kotlin/pl/allegro/logic/operators/logic/StrictNotEqualOperation.kt
+++ b/src/main/kotlin/pl/allegro/logic/operators/logic/StrictNotEqualOperation.kt
@@ -9,16 +9,16 @@ import pl.allegro.logic.StringElement
 
 internal interface StrictNotEqualOperation {
     @ClientLogicMarker
-    fun ClientLogicElement.strictNotEqual(other: ClientLogicElement) = StrictNotEqualOperatorFactory().create(this, other)
+    fun ClientLogicElement.isStrictNotEqual(other: ClientLogicElement) = StrictNotEqualOperatorFactory().create(this, other)
 
     @ClientLogicMarker
-    fun ClientLogicElement.strictNotEqual(other: String) = strictNotEqual(StringElement(other))
+    fun ClientLogicElement.isStrictNotEqual(other: String) = isStrictNotEqual(StringElement(other))
 
     @ClientLogicMarker
-    fun ClientLogicElement.strictNotEqual(other: Number) = strictNotEqual(NumberElement(other))
+    fun ClientLogicElement.isStrictNotEqual(other: Number) = isStrictNotEqual(NumberElement(other))
 
     @ClientLogicMarker
-    fun ClientLogicElement.strictNotEqual(other: Boolean) = strictNotEqual(BooleanElement(other))
+    fun ClientLogicElement.isStrictNotEqual(other: Boolean) = isStrictNotEqual(BooleanElement(other))
 }
 
 private class StrictNotEqualOperatorFactory : OperatorFactory("!==")

--- a/src/test/kotlin/pl/allegro/logic/operators/logic/AndOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/logic/operators/logic/AndOperationTest.kt
@@ -32,24 +32,22 @@ class AndOperationTest {
                         .and(registryKey("key2"))
                         .and(registryKey("key3"))
                 },
-                expected = """{"and":[{"and":[{"var":"key1"},{"var":"key2"}]},{"var":"key3"}]}"""
+                expected = """{"and":[{"var":"key1"},{"var":"key2"},{"var":"key3"}]}"""
             ),
             JsonLogicTestData(
                 testCase = "find first falsy element",
                 expression = clientLogic {
-                    firstFalsyElementOrLastElement(registryKey("key1"), registryKey("key2"), registryKey("key3"))
+                    registryKey("key1").and(registryKey("key2")).and(registryKey("key3"))
                 },
                 expected = """{ "and" : [{"var":"key1"}, {"var":"key2"}, {"var":"key3"}]}"""
             ),
             JsonLogicTestData(
                 testCase = "find first falsy element - keys and expression",
                 expression = clientLogic {
-                    firstFalsyElementOrLastElement(
-                        registryKey("key1"),
-                        registryKey("key2"),
-                        registryKey("key3"),
-                        2.plus(registryKey("test"))
-                    )
+                    registryKey("key1")
+                        .and(registryKey("key2"))
+                        .and(registryKey("key3"))
+                        .and(2.plus(registryKey("test")))
                 },
                 expected = """{"and":[{"var":"key1"},{"var":"key2"},{"var":"key3"},{"+":[2,{"var":"test"}]}]}"""
             ),
@@ -62,7 +60,7 @@ class AndOperationTest {
                         registryKey("key3"),
                         2.plus(registryKey("test"))
                     )
-                    firstFalsyElementOrLastElement(elements)
+                    and(elements)
                 },
                 expected = """{"and":[{"var":"key1"},{"var":"key2"},{"var":"key3"},{"+":[2,{"var":"test"}]}]}"""
             ),

--- a/src/test/kotlin/pl/allegro/logic/operators/logic/OrOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/logic/operators/logic/OrOperationTest.kt
@@ -28,26 +28,17 @@ class OrOperationTest {
             JsonLogicTestData(
                 testCase = "find first truthy element (4 params)",
                 expression = clientLogic {
-                    firstTruthyElementOrLastElement(
-                        registryKey("key1"),
-                        registryKey("key2"),
-                        registryKey("key3"),
-                        registryKey("key4")
-                    )
+                    registryKey("key1")
+                        .or(registryKey("key2"))
+                        .or(registryKey("key3"))
+                        .or(registryKey("key4"))
                 },
                 expected = """{ "or" : [{"var":"key1"}, {"var":"key2"}, {"var":"key3"}, {"var":"key4"}]}"""
             ),
             JsonLogicTestData(
-                testCase = "find first truthy element (1 param)",
-                expression = clientLogic {
-                    firstTruthyElementOrLastElement(registryKey("key1"))
-                },
-                expected = """{ "or" : {"var":"key1"}}"""
-            ),
-            JsonLogicTestData(
                 testCase = "find first truthy element - array",
                 expression = clientLogic {
-                    firstTruthyElementOrLastElement(
+                    or(
                         listOfElements(
                             registryKey("key1"),
                             registryKey("key2"),

--- a/src/test/kotlin/pl/allegro/logic/operators/logic/StrictEqualOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/logic/operators/logic/StrictEqualOperationTest.kt
@@ -21,7 +21,7 @@ class StrictEqualOperationTest {
             JsonLogicTestData(
                 testCase = "key, value",
                 expression = clientLogic {
-                    registryKey("key1").strictEqual(true)
+                    registryKey("key1").isStrictEqual(true)
                 },
                 expected = """{ "===" : [{"var":"key1"}, true]}"""
             ),
@@ -29,14 +29,14 @@ class StrictEqualOperationTest {
                 testCase = "value, expression",
                 expression = clientLogic {
                     val ifExpression = If(registryKey("key1")) { "a" }.Else { "b" }
-                    ifExpression.strictEqual("a")
+                    ifExpression.isStrictEqual("a")
                 },
                 expected = """{"===":[{"if":[{"var":"key1"},"a","b"]}, "a"]}"""
             ),
             JsonLogicTestData(
                 testCase = "key, number",
                 expression = clientLogic {
-                    registryKey("A").strictEqual(2.22)
+                    registryKey("A").isStrictEqual(2.22)
                 },
                 expected = """{"===":[{"var":"A"},2.22]}"""
             ),

--- a/src/test/kotlin/pl/allegro/logic/operators/logic/StrictNotEqualOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/logic/operators/logic/StrictNotEqualOperationTest.kt
@@ -21,21 +21,21 @@ class StrictNotEqualOperationTest {
             JsonLogicTestData(
                 testCase = "key, string",
                 expression = clientLogic {
-                    registryKey("key1").strictNotEqual("false")
+                    registryKey("key1").isStrictNotEqual("false")
                 },
                 expected = """{ "!==" : [{"var":"key1"}, "false"]}"""
             ),
             JsonLogicTestData(
                 testCase = "key, boolean",
                 expression = clientLogic {
-                    registryKey("key1").strictNotEqual(false)
+                    registryKey("key1").isStrictNotEqual(false)
                 },
                 expected = """{ "!==" : [{"var":"key1"}, false]}"""
             ),
             JsonLogicTestData(
                 testCase = "key, int",
                 expression = clientLogic {
-                    registryKey("key1").strictNotEqual(2)
+                    registryKey("key1").isStrictNotEqual(2)
                 },
                 expected = """{ "!==" : [{"var":"key1"}, 2]}"""
             ),


### PR DESCRIPTION
## What:
- `strictEqual` -> `isStrictEqual`
- `firstFalsyElementOrLastElement` removed (using `and` will be less confusing)
- `firstTruthyElementOrLastElement` removed (using `or` will be less confusing)

## Why:
To make DSL easier to use