### PR TITLE
unify lessOrEqual, greaterOrEqual

### DIFF
--- a/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
@@ -29,8 +29,8 @@ import pl.allegro.mobile.logic.operators.logic.StrictNotEqualOperation
 import pl.allegro.mobile.logic.operators.miscelanous.LogOperation
 import pl.allegro.mobile.logic.operators.numeric.BetweenOperation
 import pl.allegro.mobile.logic.operators.numeric.BetweenOrEqualOperation
-import pl.allegro.mobile.logic.operators.numeric.GreaterOrEqualThanOperation
-import pl.allegro.mobile.logic.operators.numeric.LessOrEqualThanOperation
+import pl.allegro.mobile.logic.operators.numeric.GreaterOrEqualOperation
+import pl.allegro.mobile.logic.operators.numeric.LessOrEqualOperation
 import pl.allegro.mobile.logic.operators.numeric.LessThanOperation
 import pl.allegro.mobile.logic.operators.numeric.MaxOperation
 import pl.allegro.mobile.logic.operators.numeric.MinOperation
@@ -81,9 +81,9 @@ object ClientLogic :
     // numeric
     BetweenOperation,
     BetweenOrEqualOperation,
-    GreaterOrEqualThanOperation,
+    GreaterOrEqualOperation,
     GreaterThanOperation,
-    LessOrEqualThanOperation,
+    LessOrEqualOperation,
     LessThanOperation,
     MaxOperation,
     MinOperation,

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/GreaterOrEqualOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/GreaterOrEqualOperation.kt
@@ -5,7 +5,7 @@ import pl.allegro.mobile.logic.NumberElement
 import pl.allegro.mobile.logic.ClientLogicMarker
 import pl.allegro.mobile.logic.operators.OperatorFactory
 
-internal interface GreaterOrEqualThanOperation {
+internal interface GreaterOrEqualOperation {
     @ClientLogicMarker
     fun ClientLogicElement.isGreaterOrEqual(other: ClientLogicElement) = GreaterOrEqualOperatorFactory().create(this, other)
 

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/LessOrEqualOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/LessOrEqualOperation.kt
@@ -5,16 +5,16 @@ import pl.allegro.mobile.logic.NumberElement
 import pl.allegro.mobile.logic.ClientLogicMarker
 import pl.allegro.mobile.logic.operators.OperatorFactory
 
-internal interface LessOrEqualThanOperation {
+internal interface LessOrEqualOperation {
 
     @ClientLogicMarker
-    fun ClientLogicElement.isLessOrEqualThan(other: ClientLogicElement) = LessOrEqualThanOperatorFactory().create(this, other)
+    fun ClientLogicElement.isLessOrEqual(other: ClientLogicElement) = LessOrEqualThanOperatorFactory().create(this, other)
 
     @ClientLogicMarker
-    fun ClientLogicElement.isLessOrEqualThan(other: Number) = isLessOrEqualThan(NumberElement(other))
+    fun ClientLogicElement.isLessOrEqual(other: Number) = isLessOrEqual(NumberElement(other))
 
     @ClientLogicMarker
-    fun Int.isLessOrEqualThan(other: ClientLogicElement) = NumberElement(this).isLessOrEqualThan(other)
+    fun Int.isLessOrEqual(other: ClientLogicElement) = NumberElement(this).isLessOrEqual(other)
 }
 
 internal class LessOrEqualThanOperatorFactory : OperatorFactory("<=")

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/numeric/LessOrEqualThanOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/numeric/LessOrEqualThanOperationTest.kt
@@ -24,14 +24,14 @@ class LessOrEqualThanOperationTest {
                 JsonLogicTestData(
                     testCase = "key, value",
                     expression = clientLogic {
-                        registryKey("temp").isLessOrEqualThan(4)
+                        registryKey("temp").isLessOrEqual(4)
                     },
                     expected = """{ "<=" : [{"var":"temp"}, 4]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "int, operation",
                     expression = clientLogic {
-                        8.isLessOrEqualThan(registryKey("test").plus(99))
+                        8.isLessOrEqual(registryKey("test").plus(99))
                     },
                     expected = """{"<=":[8,{"+":[{"var":"test"},99]}]}"""
                 ),
@@ -39,7 +39,7 @@ class LessOrEqualThanOperationTest {
                     testCase = "key, operation",
                     expression = clientLogic {
                         registryKey("test1")
-                            .isLessOrEqualThan(registryKey("test2").divide(2))
+                            .isLessOrEqual(registryKey("test2").divide(2))
                     },
                     expected = """{"<=":[{"var":"test1"},{"/":[{"var":"test2"},2]}]}"""
                 ),


### PR DESCRIPTION
## What:
unify operator names: `lessOrEqual`, `greaterOrEqual` (remove `Than`)

## Why:
consistency