### PR TITLE
Join to string operation dsl

### DIFF
--- a/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
@@ -10,6 +10,7 @@ import pl.allegro.mobile.logic.operators.array.AllOperation
 import pl.allegro.mobile.logic.operators.array.DistinctOperation
 import pl.allegro.mobile.logic.operators.array.FilterOperation
 import pl.allegro.mobile.logic.operators.array.InOperation
+import pl.allegro.mobile.logic.operators.array.JoinToStringOperation
 import pl.allegro.mobile.logic.operators.array.MapOperation
 import pl.allegro.mobile.logic.operators.array.MergeOperation
 import pl.allegro.mobile.logic.operators.array.NoneOperation
@@ -73,6 +74,7 @@ object ClientLogic :
     SomeOperation,
     SizeOperation,
     DistinctOperation,
+    JoinToStringOperation,
 
     // data access
     MissingOperation,

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/array/DistinctOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/array/DistinctOperation.kt
@@ -3,6 +3,7 @@ package pl.allegro.mobile.logic.operators.array
 import pl.allegro.mobile.logic.ClientLogicArray
 import pl.allegro.mobile.logic.ClientLogicElement
 import pl.allegro.mobile.logic.ClientLogicMarker
+import pl.allegro.mobile.logic.ClientLogicOperator
 import pl.allegro.mobile.logic.operators.OperatorFactory
 
 internal interface DistinctOperation {
@@ -17,4 +18,6 @@ internal interface DistinctOperation {
     fun <T : ClientLogicElement> ClientLogicArray<T>.distinct() = DistinctOperatorFactory().create(this)
 }
 
-private class DistinctOperatorFactory : OperatorFactory("distinct")
+private class DistinctOperatorFactory : ArrayOperatorFactory("distinct") {
+    fun create(vararg elements: ClientLogicElement) = ClientLogicOperator(name, *elements)
+}

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperation.kt
@@ -26,23 +26,30 @@ internal interface JoinToStringOperation {
         postfix: String = "",
         limit: Int = -1,
         truncated: String = "..."
-    ) = JoinToStringOperatorFactory().create(this, separator, prefix, postfix, limit, truncated)
+    ) = JoinToStringOperatorFactory().create(this, JoinToStringArguments(separator, prefix, postfix, limit, truncated))
 }
+
+private data class JoinToStringArguments(
+    val separator: String,
+    val prefix: String,
+    val postfix: String,
+    val limit: Int,
+    val truncated: String
+)
 
 private class JoinToStringOperatorFactory {
     fun create(
         element: ClientLogicElement,
-        separator: String,
-        prefix: String,
-        postfix: String,
-        limit: Int,
-        truncated: String
-    ) = ClientLogicOperator.Builder("joinToString")
-        .add(element)
-        .add(StringElement(separator))
-        .add(StringElement(prefix))
-        .add(StringElement(postfix))
-        .add(NumberElement(limit))
-        .add(StringElement(truncated))
-        .build()
+        arguments: JoinToStringArguments
+    ) = with(arguments) {
+        ClientLogicOperator.Builder("joinToString")
+            .add(element)
+            .add(StringElement(separator))
+            .add(StringElement(prefix))
+            .add(StringElement(postfix))
+            .add(NumberElement(limit))
+            .add(StringElement(truncated))
+            .build()
+    }
 }
+

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperation.kt
@@ -1,0 +1,48 @@
+package pl.allegro.mobile.logic.operators.array
+
+import pl.allegro.mobile.logic.ClientLogicArray
+import pl.allegro.mobile.logic.ClientLogicElement
+import pl.allegro.mobile.logic.ClientLogicMarker
+import pl.allegro.mobile.logic.ClientLogicOperator
+import pl.allegro.mobile.logic.NumberElement
+import pl.allegro.mobile.logic.StringElement
+
+internal interface JoinToStringOperation {
+    /**
+     * Creates a string from all the elements separated using separator and using the given prefix and postfix if supplied.
+     * @receiver list of client side elements (use buildListOfElements or listOfElements) or client side operation that returns array
+     * @param prefix character sequence put at the start of the joint collection elements
+     * @param postfix character sequence put at the end of the joint collection elements
+     * @param limit number of elements before truncated string
+     * @param truncated replaces rest of the elements when the limit is reached
+     * @return joinToString operator, evaluated client side.
+     * Operator returns a string from all the elements
+     * @see: JoinToStringOperationTest
+     */
+    @ClientLogicMarker
+    fun <T : ClientLogicElement> ClientLogicArray<T>.joinToString(
+        separator: String = ", ",
+        prefix: String = "",
+        postfix: String = "",
+        limit: Int = -1,
+        truncated: String = "..."
+    ) = JoinToStringOperatorFactory().create(this, separator, prefix, postfix, limit, truncated)
+}
+
+private class JoinToStringOperatorFactory {
+    fun create(
+        element: ClientLogicElement,
+        separator: String,
+        prefix: String,
+        postfix: String,
+        limit: Int,
+        truncated: String
+    ) = ClientLogicOperator.Builder("joinToString")
+        .add(element)
+        .add(StringElement(separator))
+        .add(StringElement(prefix))
+        .add(StringElement(postfix))
+        .add(NumberElement(limit))
+        .add(StringElement(truncated))
+        .build()
+}

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
@@ -1,0 +1,107 @@
+package pl.allegro.mobile.logic.operators.array
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import pl.allegro.mobile.logic.clientLogic
+import pl.allegro.mobile.logic.operators.JsonLogicTestData
+import pl.allegro.mobile.logic.operators.assertSerializedExpressionMatchesExpected
+import pl.allegro.mobile.logic.operators.toJsonLogicTestArgumentsStream
+import java.util.stream.Stream
+import org.junit.jupiter.params.provider.Arguments
+
+class JoinToStringOperationTest {
+
+    @ParameterizedTest(name = "[{index}] JOINTOSTRING operator - {0}")
+    @MethodSource("testData")
+    fun `should map joinToString operations to json`(testCaseName: String, jsonLogicTestData: JsonLogicTestData) {
+        jsonLogicTestData.assertSerializedExpressionMatchesExpected()
+    }
+
+    companion object {
+        @JvmStatic
+        fun testData(): Stream<Arguments?>? {
+            return listOf(
+                JsonLogicTestData(
+                    testCase = "extension from list of keys, all default",
+                    expression = clientLogic {
+                        listOfElements(registryKey("a"), registryKey("b")).joinToString()
+                    },
+                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from list of keys, changed prefix",
+                    expression = clientLogic {
+                        listOfElements(registryKey("tree"), registryKey("fruit")).joinToString(prefix = "<")
+                    },
+                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from list of keys, changed postfix",
+                    expression = clientLogic {
+                        listOfElements(registryKey("a"), registryKey("b")).joinToString(postfix = ">")
+                    },
+                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from list of keys, changed limit",
+                    expression = clientLogic {
+                        listOfElements(registryKey("a"), registryKey("b")).joinToString(limit = 2)
+                    },
+                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from list of keys, changed truncated",
+                    expression = clientLogic {
+                        listOfElements(registryKey("greeting"), registryKey("mode")).joinToString(truncated = "!!!")
+                    },
+                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from some operation, all default",
+                    expression = clientLogic {
+                        listOfElements(registryKey("flag0"), registryKey("flag2"))
+                            .some { it.isEqual(true) }.joinToString()
+                    },
+                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from map operation, changed prefix",
+                    expression = clientLogic {
+                        buildListOfElements {
+                            add(1)
+                            add(2)
+                            add(registryKey("test"))
+                        }.map { it.multiply(2) }.joinToString(prefix = "answer: ")
+                    },
+                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"asc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from none operation, changed postfix",
+                    expression = clientLogic {
+                        listOfElements(registryKey("element1"), registryKey("element2"))
+                            .none {
+                                it.plus(2).isLessThan(registryKey("test"))
+                            }.joinToString(postfix = "!")
+                    },
+                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"desc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from distinct operation, changed limit",
+                    expression = clientLogic {
+                        listOfElements(registryKey("number1"), registryKey("number2"))
+                            .distinct().joinToString(limit = 10)
+                    },
+                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"desc"]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "extension from some operation, changed truncated",
+                    expression = clientLogic {
+                        listOfElements(registryKey("flag0"), registryKey("flag2"))
+                            .some { it.isEqual("my_test") }.joinToString(truncated = "??")
+                    },
+                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"desc"]}"""
+                ),
+            ).toJsonLogicTestArgumentsStream()
+        }
+    }
+}

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
@@ -1,13 +1,13 @@
 package pl.allegro.mobile.logic.operators.array
 
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import pl.allegro.mobile.logic.clientLogic
 import pl.allegro.mobile.logic.operators.JsonLogicTestData
 import pl.allegro.mobile.logic.operators.assertSerializedExpressionMatchesExpected
 import pl.allegro.mobile.logic.operators.toJsonLogicTestArgumentsStream
 import java.util.stream.Stream
-import org.junit.jupiter.params.provider.Arguments
 
 class JoinToStringOperationTest {
 
@@ -78,12 +78,12 @@ class JoinToStringOperationTest {
                 JsonLogicTestData(
                     testCase = "extension from none operation, changed postfix",
                     expression = clientLogic {
-                        listOfElements(registryKey("element1"), registryKey("element2"))
+                        listOfElements(registryKey("key1"), registryKey("key2"))
                             .none {
-                                it.plus(2).isLessThan(registryKey("test"))
+                                it.isLessThan(registryKey("test"))
                             }.joinToString(postfix = "!")
                     },
-                    expected = """{"joinToString":[{"none":[[{"var":"element1"},{"var":"element2"}],{"<":[{"+":[{"var":""},2]},{"var":"test"}]}]},",","","!",-1,"..."]}"""
+                    expected = """{"joinToString":[{"none":[[{"var":"key1"},{"var":"key2"}],{"<":[{"var":""},{"var":"test"}]}]},",","","!",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from distinct operation, changed limit",

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
@@ -78,12 +78,12 @@ class JoinToStringOperationTest {
                 JsonLogicTestData(
                     testCase = "extension from none operation, changed postfix",
                     expression = clientLogic {
-                        listOfElements(registryKey("key1"), registryKey("key2"))
+                        listOfElements(registryKey("key1"))
                             .none {
                                 it.isLessThan(registryKey("test"))
                             }.joinToString(postfix = "!")
                     },
-                    expected = """{"joinToString":[{"none":[[{"var":"key1"},{"var":"key2"}],{"<":[{"var":""},{"var":"test"}]}]},",","","!",-1,"..."]}"""
+                    expected = """{"joinToString":[{"none":[[{"var":"key1"}],{"<":[{"var":""},{"var":"test"}]}]},",","","!",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from distinct operation, changed limit",

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
@@ -78,8 +78,7 @@ class JoinToStringOperationTest {
                 JsonLogicTestData(
                     testCase = "extension from none operation, changed postfix",
                     expression = clientLogic {
-                        listOfElements(registryKey("key1"))
-                            .none {
+                        listOfElements(registryKey("key1")).none {
                                 it.isLessThan(registryKey("test"))
                             }.joinToString(postfix = "!")
                     },

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/array/JoinToStringOperationTest.kt
@@ -26,35 +26,35 @@ class JoinToStringOperationTest {
                     expression = clientLogic {
                         listOfElements(registryKey("a"), registryKey("b")).joinToString()
                     },
-                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                    expected = """{"joinToString":[[{"var":"a"},{"var":"b"}],",","","",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from list of keys, changed prefix",
                     expression = clientLogic {
                         listOfElements(registryKey("tree"), registryKey("fruit")).joinToString(prefix = "<")
                     },
-                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                    expected = """{"joinToString":[[{"var":"tree"},{"var":"fruit"}],",","<","",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from list of keys, changed postfix",
                     expression = clientLogic {
                         listOfElements(registryKey("a"), registryKey("b")).joinToString(postfix = ">")
                     },
-                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                    expected = """{"joinToString":[[{"var":"a"},{"var":"b"}],",","",">",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from list of keys, changed limit",
                     expression = clientLogic {
                         listOfElements(registryKey("a"), registryKey("b")).joinToString(limit = 2)
                     },
-                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                    expected = """{"joinToString":[[{"var":"a"},{"var":"b"}],",","","",2,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from list of keys, changed truncated",
                     expression = clientLogic {
                         listOfElements(registryKey("greeting"), registryKey("mode")).joinToString(truncated = "!!!")
                     },
-                    expected = """{"sort":[[{"var":"vegetables"},{"var":"fruits"}],"asc"]}"""
+                    expected = """{"joinToString":[[{"var":"greeting"},{"var":"mode"}],",","","",-1,"!!!"]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from some operation, all default",
@@ -62,7 +62,7 @@ class JoinToStringOperationTest {
                         listOfElements(registryKey("flag0"), registryKey("flag2"))
                             .some { it.isEqual(true) }.joinToString()
                     },
-                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"asc"]}"""
+                    expected = """{"joinToString":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},",","","",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from map operation, changed prefix",
@@ -71,9 +71,9 @@ class JoinToStringOperationTest {
                             add(1)
                             add(2)
                             add(registryKey("test"))
-                        }.map { it.multiply(2) }.joinToString(prefix = "answer: ")
+                        }.map { it.multiply(2) }.joinToString(prefix = "answer: ").distinct()
                     },
-                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"asc"]}"""
+                    expected = """{"distinct":{"joinToString":[{"map":[[1,2,{"var":"test"}],{"*":[{"var":""},2]}]},",","answer:","",-1,"..."]}}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from none operation, changed postfix",
@@ -83,7 +83,7 @@ class JoinToStringOperationTest {
                                 it.plus(2).isLessThan(registryKey("test"))
                             }.joinToString(postfix = "!")
                     },
-                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"desc"]}"""
+                    expected = """{"joinToString":[{"none":[[{"var":"element1"},{"var":"element2"}],{"<":[{"+":[{"var":""},2]},{"var":"test"}]}]},",","","!",-1,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from distinct operation, changed limit",
@@ -91,7 +91,7 @@ class JoinToStringOperationTest {
                         listOfElements(registryKey("number1"), registryKey("number2"))
                             .distinct().joinToString(limit = 10)
                     },
-                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"desc"]}"""
+                    expected = """{"joinToString":[{"distinct":[{"var":"number1"},{"var":"number2"}]},",","","",10,"..."]}"""
                 ),
                 JsonLogicTestData(
                     testCase = "extension from some operation, changed truncated",
@@ -99,7 +99,7 @@ class JoinToStringOperationTest {
                         listOfElements(registryKey("flag0"), registryKey("flag2"))
                             .some { it.isEqual("my_test") }.joinToString(truncated = "??")
                     },
-                    expected = """{"sort":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},true]}]},"desc"]}"""
+                    expected = """{"joinToString":[{"some":[[{"var":"flag0"},{"var":"flag2"}],{"==":[{"var":""},"my_test"]}]},",","","",-1,"??"]}"""
                 ),
             ).toJsonLogicTestArgumentsStream()
         }


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* joinToString operation dsl - creates a string from all the elements separated using separator and using the given prefix and postfix if supplied.

## Why:
<!--- Why is this change required? What problem does it solve? -->
* to extend standard library possibilities

## Example:
<!--- Share some code snippets to show the idea in action. -->
* see unit tests