### PR TITLE
MBOX-4240 add format for case when both params are Exact(0)

### DIFF
--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperation.kt
@@ -39,14 +39,15 @@ private class DecimalFormatOperatorFactory {
         .add(element)
         .build()
 
+    @Suppress("MaxLineLength")
     private fun resolveFormatString(
         stringWidth: DecimalFormatLength,
         decimalPlaces: DecimalFormatLength
     ): StringElement {
        val formatString = when {
-           (stringWidth is DecimalFormatLength.Exact && stringWidth.width == 0)    -> "%.${decimalPlaces.toStringSize()}f"
-           decimalPlaces is DecimalFormatLength.Unmodified                          -> "%${stringWidth.toStringSize()}f"
-           else                                                                     -> "%${stringWidth.toStringSize()}.${decimalPlaces.toStringSize()}f"
+           (stringWidth is DecimalFormatLength.Exact && stringWidth.width == 0) -> "%.${decimalPlaces.toStringSize()}f"
+           decimalPlaces is DecimalFormatLength.Unmodified                      -> "%${stringWidth.toStringSize()}f"
+           else                                                                 -> "%${stringWidth.toStringSize()}.${decimalPlaces.toStringSize()}f"
        }
         return StringElement(formatString)
     }

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperation.kt
@@ -39,16 +39,18 @@ private class DecimalFormatOperatorFactory {
         .add(element)
         .build()
 
-    @Suppress("MaxLineLength")
     private fun resolveFormatString(
         stringWidth: DecimalFormatLength,
         decimalPlaces: DecimalFormatLength
     ): StringElement {
-       val formatString = when {
-           (stringWidth is DecimalFormatLength.Exact && stringWidth.width == 0) -> "%.${decimalPlaces.toStringSize()}f"
-           decimalPlaces is DecimalFormatLength.Unmodified                      -> "%${stringWidth.toStringSize()}f"
-           else                                                                 -> "%${stringWidth.toStringSize()}.${decimalPlaces.toStringSize()}f"
-       }
+        val widthSize: () -> String = { stringWidth.toStringSize() }
+        val placesSize: () -> String = { decimalPlaces.toStringSize() }
+
+        val formatString = when {
+           (stringWidth is DecimalFormatLength.Exact && stringWidth.width == 0) -> "%.${placesSize()}f"
+           decimalPlaces is DecimalFormatLength.Unmodified                      -> "%${widthSize()}f"
+           else                                                                 -> "%${widthSize()}.${placesSize()}f"
+        }
         return StringElement(formatString)
     }
 

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperation.kt
@@ -43,22 +43,21 @@ private class DecimalFormatOperatorFactory {
         stringWidth: DecimalFormatLength,
         decimalPlaces: DecimalFormatLength
     ): StringElement {
-        val formatString = if (decimalPlaces is DecimalFormatLength.Unmodified) {
-            "%${stringWidth.toStringSize()}f"
-        } else {
-            "%${stringWidth.toStringSize()}.${decimalPlaces.toStringSize()}f"
-        }
-
+       val formatString = when {
+           (stringWidth is DecimalFormatLength.Exact && stringWidth.width == 0)    -> "%.${decimalPlaces.toStringSize()}f"
+           decimalPlaces is DecimalFormatLength.Unmodified                          -> "%${stringWidth.toStringSize()}f"
+           else                                                                     -> "%${stringWidth.toStringSize()}.${decimalPlaces.toStringSize()}f"
+       }
         return StringElement(formatString)
     }
 
     private fun DecimalFormatLength.toStringSize() = when (this) {
         is DecimalFormatLength.Unmodified -> ""
-        is DecimalFormatLength.Exact      -> length.toString()
+        is DecimalFormatLength.Exact      -> width.toString()
     }
 }
 
 sealed class DecimalFormatLength {
     object Unmodified : DecimalFormatLength()
-    data class Exact(val length: Int) : DecimalFormatLength()
+    data class Exact(val width: Int) : DecimalFormatLength()
 }

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/numeric/DecimalFormatOperationTest.kt
@@ -83,6 +83,16 @@ class DecimalFormatOperationTest {
                 },
                 expected = """{"decimalFormat":["%f",{"var":"someString0"}]}"""
             ),
+            JsonLogicTestData(
+                testCase = "extension, exact zero width and exact zero decimal places",
+                expression = clientLogic {
+                    registryKey("someString0").formatDecimal(
+                        minWidth = DecimalFormatLength.Exact(0),
+                        decimalPlaces = DecimalFormatLength.Exact(0)
+                    )
+                },
+                expected = """{"decimalFormat":["%.0f",{"var":"someString0"}]}"""
+            )
         ).toJsonLogicTestArgumentsStream()
     }
 }


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* add format for case when both params are Exact(0)

## Why:
<!--- Why is this change required? What problem does it solve? -->
* Because now for this case method returns `"%0.0f"` that is not understood by Android
