### PR TITLE
Add handling string.split(delimiters)

### DIFF
--- a/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
@@ -43,7 +43,6 @@ import pl.allegro.mobile.logic.operators.numeric.LessOrEqualOperation
 import pl.allegro.mobile.logic.operators.numeric.LessThanOperation
 import pl.allegro.mobile.logic.operators.numeric.MaxOperation
 import pl.allegro.mobile.logic.operators.numeric.MinOperation
-import pl.allegro.mobile.logic.operators.string.*
 import pl.allegro.mobile.logic.operators.string.CapitalizeOperation
 import pl.allegro.mobile.logic.operators.string.CompareToDateOperation
 import pl.allegro.mobile.logic.operators.string.ConcatenateOperation
@@ -58,6 +57,7 @@ import pl.allegro.mobile.logic.operators.string.SubstringOperation
 import pl.allegro.mobile.logic.operators.string.ToArrayOperation
 import pl.allegro.mobile.logic.operators.string.TrimOperation
 import pl.allegro.mobile.logic.operators.string.UppercaseOperation
+import pl.allegro.mobile.logic.operators.string.SplitOperation
 
 @ClientLogicMarker
 fun clientLogic(init: ClientLogic.() -> ClientLogicElement): ClientLogicElement {

--- a/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/ClientLogic.kt
@@ -43,8 +43,9 @@ import pl.allegro.mobile.logic.operators.numeric.LessOrEqualOperation
 import pl.allegro.mobile.logic.operators.numeric.LessThanOperation
 import pl.allegro.mobile.logic.operators.numeric.MaxOperation
 import pl.allegro.mobile.logic.operators.numeric.MinOperation
-import pl.allegro.mobile.logic.operators.string.CompareToDateOperation
+import pl.allegro.mobile.logic.operators.string.*
 import pl.allegro.mobile.logic.operators.string.CapitalizeOperation
+import pl.allegro.mobile.logic.operators.string.CompareToDateOperation
 import pl.allegro.mobile.logic.operators.string.ConcatenateOperation
 import pl.allegro.mobile.logic.operators.string.ContainsStringOperation
 import pl.allegro.mobile.logic.operators.string.EncodeOperation
@@ -129,6 +130,7 @@ object ClientLogic :
     EncodeOperation,
     MatchOperation,
     CompareToDateOperation,
+    SplitOperation,
 
     // misc
     LogOperation,

--- a/src/main/kotlin/pl/allegro/mobile/logic/operators/string/SplitOperation.kt
+++ b/src/main/kotlin/pl/allegro/mobile/logic/operators/string/SplitOperation.kt
@@ -1,0 +1,31 @@
+package pl.allegro.mobile.logic.operators.string
+
+import pl.allegro.mobile.logic.ClientLogic.toListOfElements
+import pl.allegro.mobile.logic.ClientLogicElement
+import pl.allegro.mobile.logic.ClientLogicMarker
+import pl.allegro.mobile.logic.ClientLogicOperator
+import pl.allegro.mobile.logic.StringElement
+
+internal interface SplitOperation {
+    /**
+     * Splits string to a list of strings around occurrences of the specified delimiters.
+     * @receiver Character sequence or client side operation that returns string
+     * @param delimiters One or more characters to be used as delimiters
+     * @return split operator, evaluated client side.
+     * Returns list of strings.
+     * @see: SplitOperationTest
+     */
+    @ClientLogicMarker
+    fun ClientLogicElement.split(vararg delimiters: String) =
+        SplitOperatorFactory().create(this, delimiters.toList())
+}
+
+private class SplitOperatorFactory {
+    fun create(
+        element: ClientLogicElement,
+        delimiters: List<String>,
+    ) = ClientLogicOperator.Builder("split")
+        .add(element)
+        .add(delimiters.distinct().map { StringElement(it) }.toListOfElements())
+        .build()
+}

--- a/src/test/kotlin/pl/allegro/mobile/logic/operators/string/SplitOperationTest.kt
+++ b/src/test/kotlin/pl/allegro/mobile/logic/operators/string/SplitOperationTest.kt
@@ -1,0 +1,47 @@
+package pl.allegro.mobile.logic.operators.string
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import pl.allegro.mobile.logic.clientLogic
+import pl.allegro.mobile.logic.operators.JsonLogicTestData
+import pl.allegro.mobile.logic.operators.assertSerializedExpressionMatchesExpected
+import pl.allegro.mobile.logic.operators.toJsonLogicTestArgumentsStream
+import java.util.stream.Stream
+
+class SplitOperationTest {
+    @ParameterizedTest(name = "[{index}] SPLIT operator - {0}")
+    @MethodSource("testData")
+    fun `should map Split operations to json`(testCaseName: String, jsonLogicTestData: JsonLogicTestData) {
+        jsonLogicTestData.assertSerializedExpressionMatchesExpected()
+    }
+
+    companion object {
+        @JvmStatic
+        fun testData(): Stream<Arguments?>? {
+            return listOf(
+                JsonLogicTestData(
+                    testCase = "split on string element with one delimiter",
+                    expression = clientLogic {
+                        registryKey("one,two,three").split(",")
+                    },
+                    expected = """{"split":[{"var":"one,two,three"},[","]]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "split on string element with two delimiters",
+                    expression = clientLogic {
+                        registryKey("one,two,three").split(",", ";")
+                    },
+                    expected = """{"split":[{"var":"one,two,three"},[",", ";"]]}"""
+                ),
+                JsonLogicTestData(
+                    testCase = "split on string element without delimiter",
+                    expression = clientLogic {
+                        registryKey("one,two,three").split()
+                    },
+                    expected = """{"split":[{"var":"one,two,three"},[]]}"""
+                ),
+            ).toJsonLogicTestArgumentsStream()
+        }
+    }
+}


### PR DESCRIPTION
## What:
* Added new `split` operator for string

## Why:
* Request from users. 

## Example:
```
clientLogic {
    registryKey("one,two,three").split(",")
}
```